### PR TITLE
Joss review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - import of Helper not necessary (then asked for Github token) (0.0.31) 
  - instructions must be for Github app (personal token not scoped correctly) (0.0.3) 
  - first alpha release with uservoice and github helpers (0.0.2)
  - dummy information release on pypi (0.0.1)

--- a/README.md
+++ b/README.md
@@ -2,23 +2,26 @@
 
 A command line helper when you need it.
 
-HelpMe is a free to use, open source command line tool that serves one purpose: to connect a user on a command line to a a resource to get help. The software provides a general framework for developers to add "helpers," or different support endpoints to work with "recorders," each a specific way of capturing information like messages, terminal recordings (asciinema), and environment, to easily submit to the endpoint. Importantly, the complex interaction of various application programming interfaces (APIs) with the user's terminal is presented in a simple and intuitive way that puts the user in control of the interaction. By default, the software comes ready to use for interaction with Github and the UserVoice ticketing softwarecommonly used in Research Computing.  The HelpMe [documentation base](https://vsoch.github.io/helpme) is rendered from the same repository and open for contribution. It provides ample detail for developers to add new helpers, recorders, and for users to install the software. For more details, please see the [paper](paper/paper.md).
+Asking for help is a standard need for research software users, and needing to perform this function from a command line is common given the headless environments provided on shared cluster resources.  While interactive web interfaces are the main avenue to submit help tickets and issues to get help, they are many steps away from the original command line where the issue arose, meaning that the user must interrupt a workflow, navigate to another program, and perform several clicks before needing to try to manually capture the problem at hand. At best, the user might copy an error message and the support staff then needs to ask or use internal resources to collect more information. This reality is not ideal because the user often presents a limited summary of the issue, and valuable information about the system, environment, or even a recording of the actual issue are lost. Extra time is spent on further communication and effort to obtain this information. HelpMe resolves these issues by recording information about the issue directly from the source, and allowing users to ask for help without leaving the working environment.
+
+HelpMe is a free to use, open source command line tool that serves one purpose: to connect a user on a command line to a a resource to get help. The software provides a general framework for developers to add "helpers," or different support endpoints to work with "recorders," each a specific way of capturing information like messages, terminal recordings (asciinema), and environment, to easily submit to the endpoint. Importantly, the complex interaction of various application programming interfaces (APIs) with the user's terminal is presented in a simple and intuitive way that puts the user in control of the interaction. By default, the software comes ready to use for interaction with Github and the UserVoice ticketing softwarecommonly used in Research Computing.  The HelpMe [documentation base](https://vsoch.github.io/helpme) is rendered from the same repository and open for contribution. It provides ample detail for developers to add new helpers, recorders, and for users to install the software.
 
 ![docs/assets/img/interface.png](docs/assets/img/interface.png)
 
 ## Docker
 
 ```bash
-docker build -t vanessa/helpme .
+$ docker build -t vanessa/helpme .
 ```
 
 ### Interactive Development
 
 ```bash
-docker run -it --entrypoint bash vanessa/helpme
+$ docker run -it --entrypoint bash vanessa/helpme
 ```
 
 # Overview
+
 HelpMe is a general tool that can support the addition of helpers, or different
 modules that have a set of metadata to collect for the user, and based on an internal
 configuration file to define these metadata, and (if needed) an external config file
@@ -42,6 +45,13 @@ $ helpme uservoice
 ```
 
 For more details, see our [documentation](https://vsoch.github.io/helpme).
+
+## Contributing
+
+If you'd like to contribute, we welcome pull requests, feature requests, and any form of help you
+might offer! Please see our [contributing guidelines](.github/CONTRIBUTING.md) for more details. Do you
+have a question, or did you find a bug? You can [submit an issue](https://www.github.com/vsoch/helpme/issues)
+and we will help you out.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A command line helper when you need it.
 
+HelpMe is a free to use, open source command line tool that serves one purpose: to connect a user on a command line to a a resource to get help. The software provides a general framework for developers to add "helpers," or different support endpoints to work with "recorders," each a specific way of capturing information like messages, terminal recordings (asciinema), and environment, to easily submit to the endpoint. Importantly, the complex interaction of various application programming interfaces (APIs) with the user's terminal is presented in a simple and intuitive way that puts the user in control of the interaction. By default, the software comes ready to use for interaction with Github and the UserVoice ticketing softwarecommonly used in Research Computing.  The HelpMe [documentation base](https://vsoch.github.io/helpme) is rendered from the same repository and open for contribution. It provides ample detail for developers to add new helpers, recorders, and for users to install the software. For more details, please see the [paper](paper/paper.md).
+
 ![docs/assets/img/interface.png](docs/assets/img/interface.png)
 
 ## Docker

--- a/helpme/client/__init__.py
+++ b/helpme/client/__init__.py
@@ -101,7 +101,6 @@ def main():
 
     # Customize parser
 
-    from helpme.main import Helper
     parser = get_parser()
     subparsers = get_subparsers(parser)
 
@@ -112,8 +111,8 @@ def main():
 
         version = helpme.__version__
         
-        bot.custom(message='HelpMe Command Line Tool v%s' %version,
-                   prefix='\n[%s]' %Helper.name, 
+        bot.custom(message='Command Line Tool v%s' %version,
+                   prefix='\n[HelpMe] ', 
                    color='CYAN')
 
         parser.print_help()

--- a/helpme/version.py
+++ b/helpme/version.py
@@ -46,6 +46,7 @@ LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
     ('requests', {'min_version': '2.18.4'}),
+    ('asciinema', {'min_version': '2.0.1'}),
 )
 
 ################################################################################

--- a/helpme/version.py
+++ b/helpme/version.py
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 '''
 
-__version__ = "0.0.3"
+__version__ = "0.0.31"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'helpme'

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -4,6 +4,7 @@
   author       = "{vsoch}",
   abstract     = "HelpMe - a command line tool for helping you out.",
   publisher    = "vsoch",
+  year        = {2018},
   howpublished = "\url{https://vsoch.github.io/helpme/helpme/}",
   note         = "Accessed: 2018-4-30"
 }
@@ -12,6 +13,7 @@
 @MISC{asciinema,
   title        = "asciinema - Record and share your terminal sessions, the
                   right way",
+  year        = {2018},
   howpublished = "\url{https://asciinema.org/}",
   note         = "Accessed: 2018-4-30"
 }
@@ -20,6 +22,7 @@
   title        = "Introducing {UserVoice} Helpdesk, a Support Tool that Doesn't
                   Suck | {UserVoice} Blog",
   howpublished = "\url{https://community.uservoice.com/blog/introducing-uservoice-helpdesk-a-support-tool-that-doesnt-suck/}",
+  year        = {2011},
   note         = "Accessed: 2018-4-30"
 }
 
@@ -34,9 +37,9 @@
 @MISC{software,
   title       = "helpme",
   author      = "Sochat, Vanessa",
+  year        = {2018},
   abstract    = "GitHub is where people build software. More than 27 million
                  people use GitHub to discover, fork, and contribute to over 80
                  million projects.",
   institution = "Github"
 }
-


### PR DESCRIPTION
This will fix more issues for the JOSS review, specifically:
 - #19 the help command should not require having the default (Github) token exported. This was a bug that resulted because the Helper was imported at the top of the script.
 - #18 a missing dependency (asciinema)