### PR TITLE
Adding more simple install for just github or basic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/singularityhub/sregistry-cli/tree/master) (0.0.x)
+ - basic install should not include all extra requirements (0.0.41)
  - asciinema shouldn't be required for base function (0.0.40)
  - GitHub submit via link (without token) option added (0.0.39)
  - adding GitHub CI and linting with black (0.0.36)

--- a/helpme/main/discourse/__init__.py
+++ b/helpme/main/discourse/__init__.py
@@ -1,6 +1,6 @@
 """
 
-Copyright (C) 2018-2019 Vanessa Sochat.
+Copyright (C) 2018-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/helpme/main/discourse/utils.py
+++ b/helpme/main/discourse/utils.py
@@ -1,6 +1,6 @@
 """
 
-Copyright (C) 2018-2019 Vanessa Sochat.
+Copyright (C) 2018-2020 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/helpme/version.py
+++ b/helpme/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.40"
+__version__ = "0.0.41"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "helpme"
@@ -23,6 +23,7 @@ LICENSE = "LICENSE"
 
 
 INSTALL_REQUIRES = (("requests", {"min_version": "2.18.4"}),)
+INSTALL_GITHUB = INSTALL_REQUIRES
 
 ################################################################################
 # Submodule Requirements

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,9 @@ with open("README.md") as filey:
 
 if __name__ == "__main__":
 
-    INSTALL_REQUIRES = get_reqs(lookup, "INSTALL_ALL")
+    INSTALL_ALL = get_reqs(lookup, "INSTALL_ALL")
+    INSTALL_GITHUB = get_reqs(lookup, "INSTALL_GITHUB")
+    INSTALL_REQUIRES = get_reqs(lookup, "INSTALL_REQUIRES")
     INSTALL_USERVOICE = get_reqs(lookup, "INSTALL_USERVOICE")
     INSTALL_ASCIINEMA = get_reqs(lookup, "INSTALL_ASCIINEMA")
     INSTALL_DISCOURSE = get_reqs(lookup, "INSTALL_DISCOURSE")
@@ -97,10 +99,11 @@ if __name__ == "__main__":
         keywords=KEYWORDS,
         install_requires=INSTALL_REQUIRES,
         extras_require={
-            "all": [INSTALL_REQUIRES],
+            "all": [INSTALL_ALL],
             "asciinema": [INSTALL_ASCIINEMA],
             "uservoice": [INSTALL_USERVOICE],
             "discourse": [INSTALL_DISCOURSE],
+            "github": [INSTALL_GITHUB],
         },
         classifiers=[
             "Intended Audience :: Science/Research",


### PR DESCRIPTION
In preparation for adding to datalad, helpme needs to have an install option for just github (meaning the basic requirements) without uservoice, discourse, etc. This was likely an oversight that I used `INSTALL_REQUIRES` to point to `INSTALL_ALL` instead of basic requirements.

Signed-off-by: vsoch <vsochat@stanford.edu>