### PR TITLE
restore link to "Getting Started"

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,5 +1,5 @@
 - name: Getting Started
-  link: /getting-started/
+  link: /getting-started
 - name: Faq
   link: /faq
 - name: Helpers


### PR DESCRIPTION
With the trailing "/" it lead to 404.